### PR TITLE
chore!: require Node.js 22 or newer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24', '26']
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "license": "MIT",
   "repository": "github:serverless-plugins/serverless-kms-alias",
   "engines": {
-    "node": ">= 18"
+    "node": ">=22"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "3.1081.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,16 @@
     "target": "ES2022",
     "module": "ES2022",
     "lib": ["ESNext"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowJs": false,
 
     "inlineSourceMap": true,
     "skipLibCheck": true,
 
-    "baseUrl": ".",
+    "declaration": true,
+    "isolatedDeclarations": true,
+
+    "rootDir": "src",
     "outDir": "dist",
     "sourceRoot": ".",
 
@@ -21,8 +24,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Drops Node.js 20 support (end of life April 2026) and adds Node.js 26 to the CI matrix.

- `engines.node` is now `>=22`
- CI matrix: 22 / 24 / 26 (was 20 / 22 / 24)
- tsconfig: `moduleResolution` `node` → `bundler` and the unused `baseUrl` is dropped (both were removed in TypeScript 7), `declaration`/`isolatedDeclarations` are enforced so declaration output no longer depends on the TypeScript compiler API, and `rootDir` is set explicitly

Verified with the current npm toolchain: `npm run check:types` (tsc 6.0.3), `npm run build` (unbuild), and `npm run lint` all pass with the updated tsconfig.

#261 (pnpm + Vite+ toolchain migration) stacks on top of this PR.

BREAKING CHANGE: Node.js >= 22 is now required.